### PR TITLE
FEAT: 컨텐츠 맵 컴포넌트 - 구글 뉴스 구현 완료

### DIFF
--- a/src/components/common/news/google-news/Google.news.jsx
+++ b/src/components/common/news/google-news/Google.news.jsx
@@ -1,0 +1,46 @@
+const data = [
+  {
+    title: `[자막뉴스] "급성 중독 위험"…덴마크서 'K-불닭' 폐기 권고한 이유 - SBS 뉴스`,
+    link: "https://news.google.com/rss/articles/CBMiOmh0dHBzOi8vbmV3cy5zYnMuY28ua3IvbmV3cy9lbmRQYWdlLmRvP25ld3NfaWQ9TjEwMDc2ODIzMzHSATdodHRwczovL25ld3Muc2JzLmNvLmtyL2FtcC9uZXdzLmFtcD9uZXdzX2lkPU4xMDA3NjgyMzMx?oc=5",
+    pubDate: "Thu, 13 Jun 2024 04:54:00 GMT",
+    source: "SBS 뉴스",
+  },
+  {
+    title: "덴마크서 '핵불닭볶음면' 리콜… 이유 두고 갑론을박 - 헬스조선",
+    link: "https://news.google.com/rss/articles/CBMiQ2h0dHBzOi8vbS5oZWFsdGguY2hvc3VuLmNvbS9zdmMvbmV3c192aWV3Lmh0bWw_Y29udGlkPTIwMjQwNjEzMDE1MjHSAQA?oc=5",
+    pubDate: "Thu, 13 Jun 2024 04:50:00 GMT",
+    source: "헬스조선",
+  },
+  {
+    title: '"8만전자 찍나"…상위 1% 투자자 삼성전자 집중 매수 - 한국경제',
+    link: "https://news.google.com/rss/articles/CBMiLmh0dHBzOi8vd3d3Lmhhbmt5dW5nLmNvbS9hcnRpY2xlLzIwMjQwNjEzMzM0NWnSASpodHRwczovL3d3dy5oYW5reXVuZy5jb20vYW1wLzIwMjQwNjEzMzM0NWk?oc=5",
+    pubDate: "Thu, 13 Jun 2024 02:08:43 GMT",
+    source: "한국경제",
+  },
+  {
+    title: "잠실·삼성·대치·청담 일대 다시 거래제한 묶였다 - 머니S",
+    link: "https://news.google.com/rss/articles/CBMiNGh0dHBzOi8vd3d3Lm1vbmV5cy5jby5rci9hcnRpY2xlLzIwMjQwNjEzMTEwNjExNTc0ODjSAQA?oc=5",
+    pubDate: "Thu, 13 Jun 2024 02:07:42 GMT",
+    source: "머니S",
+  },
+  {
+    title:
+      "삼성디스플레이, 미니(MINI) 신차 5종에 9.4형 원형 OLED 공급 - 비즈니스포스트",
+    link: "https://news.google.com/rss/articles/CBMiQWh0dHBzOi8vd3d3LmJ1c2luZXNzcG9zdC5jby5rci9CUD9jb21tYW5kPWFydGljbGVfdmlldyZudW09MzU1MzU10gEA?oc=5",
+    pubDate: "Thu, 13 Jun 2024 01:53:40 GMT",
+    source: "비즈니스포스트",
+  },
+  {
+    title: '"삼성전자 2030년 RE100 달성하면 14조원 절감한다" - 뉴스트리',
+    link: "https://news.google.com/rss/articles/CBMiMGh0dHBzOi8vd3d3Lm5ld3N0cmVlLmtyL25ld3NWaWV3L250cjIwMjQwNjEzMDAwMdIBAA?oc=5",
+    pubDate: "Thu, 13 Jun 2024 01:52:00 GMT",
+    source: "뉴스트리",
+  },
+  {
+    title:
+      '그린피스 "국내 기업 2030년 RE100 달성 편익 커, 삼성전자 14조 원 아껴" - 비즈니스포스트',
+    link: "https://news.google.com/rss/articles/CBMiQGh0dHBzOi8vd3d3LmJ1c2luZXNzcG9zdC5jby5rci9CUD9jb21tYW5kPW1vYmlsZV92aWV3Jm51bT0zNTUzNTTSAQA?oc=5",
+    pubDate: "Thu, 13 Jun 2024 01:46:01 GMT",
+    source: "비즈니스포스트",
+  },
+];

--- a/src/components/common/news/google-news/Google.news.jsx
+++ b/src/components/common/news/google-news/Google.news.jsx
@@ -1,3 +1,28 @@
+import React from "react";
+import {
+  StyledNewsDiv,
+  StyledNewsKeyword,
+  StyledNewsItemDiv,
+  StyledNewsItemHeaderDiv,
+  StyledNewsItemPatentDiv,
+} from "./Google.style";
+
+function timeAgo(dateString) {
+  const now = new Date();
+  const articleDate = new Date(dateString);
+  const differenceInMilliseconds = now - articleDate;
+  const differenceInHours = Math.floor(
+    differenceInMilliseconds / (1000 * 60 * 60)
+  );
+
+  if (differenceInHours < 24) {
+    return `${differenceInHours}시간 전`;
+  } else {
+    const differenceInDays = Math.floor(differenceInHours / 24);
+    return `${differenceInDays}일 전`;
+  }
+}
+
 const data = [
   {
     title: `[자막뉴스] "급성 중독 위험"…덴마크서 'K-불닭' 폐기 권고한 이유 - SBS 뉴스`,
@@ -44,3 +69,23 @@ const data = [
     source: "비즈니스포스트",
   },
 ];
+
+export default function GoogleNews() {
+  return (
+    <StyledNewsDiv>
+      <StyledNewsKeyword>
+        <span>"불닭"</span>이 이렇게 언급됐어요
+      </StyledNewsKeyword>
+      <StyledNewsItemPatentDiv>
+        {data.map((e, index) => (
+          <StyledNewsItemDiv key={index}>
+            <StyledNewsItemHeaderDiv>
+              <span>{e.source}</span> |<span>{timeAgo(e.pubDate)}</span>
+            </StyledNewsItemHeaderDiv>
+            <div>{e.title}</div>
+          </StyledNewsItemDiv>
+        ))}
+      </StyledNewsItemPatentDiv>
+    </StyledNewsDiv>
+  );
+}

--- a/src/components/common/news/google-news/Google.style.js
+++ b/src/components/common/news/google-news/Google.style.js
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+
+export const StyledNewsDiv = styled.div`
+  width: 500px;
+  height: 500px;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 15px;
+`;
+export const StyledNewsKeyword = styled.div`
+  width: 100%;
+  font-size: 23px;
+  text-align: start;
+  margin-bottom: 20px;
+  & span {
+    font-weight: bold;
+  }
+`;
+
+export const StyledNewsItemPatentDiv = styled.div`
+  height: 450px;
+  overflow-y: scroll;
+`;
+
+export const StyledNewsItemDiv = styled.div`
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.03);
+  padding: 10px;
+  border-radius: 10px;
+  margin-bottom: 10px;
+  padding-bottom: 20px;
+`;
+
+export const StyledNewsItemHeaderDiv = styled.div`
+  font-size: 14px;
+  margin-bottom: 10px;
+  color: rgba(0, 0, 0, 0.6);
+
+  & span:nth-child(1) {
+    margin-right: 10px;
+  }
+  & span:nth-child(2) {
+    margin-left: 10px;
+  }
+`;

--- a/src/pages/main/Main.jsx
+++ b/src/pages/main/Main.jsx
@@ -1,4 +1,5 @@
 import Header from "../../components/common/header/Header";
+import GoogleNews from "../../components/common/news/google-news/Google.news";
 import Sidebar from "../../components/common/sidebar/Sidebar";
 import { StyledMainDiv } from "./Main.style";
 
@@ -8,6 +9,7 @@ export default function MainPage() {
       <Sidebar />
       <div>
         <Header />
+        <GoogleNews />
       </div>
     </StyledMainDiv>
   );


### PR DESCRIPTION
## #️⃣ 작업한 내용 요약
> 다음과 같은 형태로 적어주세요 (ex. - [ ] 작업 내용 || - [x] 작업 내용)

- [ ] 소셜 페이지의 구글 뉴스 컴포넌트를 구현했습니다.
       현재는 더미 데이터를 사용해서 구현했습니다.
       rss라는 곳에서 데이터를 받아와서 같은 형식으로 더미 데이터를 만들었습니다.

## 🍩 위키에 올릴 내용 정리
> 위키에 올릴 내용을 정리해주세요 (자유롭게 적어주세요)
x
## ⚙️ 이슈 번호
> 관련된 이슈를 적어주세요 (ex. -close #37 || #37)
- #14 
<br></br>
